### PR TITLE
Fix addons without repo/unused repository checks

### DIFF
--- a/default.py
+++ b/default.py
@@ -1261,7 +1261,7 @@ def getPathAddons(xmlFile, repo):
     try:
         xmldoc = minidom.parseString(httpdata)
     except Exception as e:
-        xbmc.log("KCLEANER >> ERROR PARSING REPO >> " + str(e).encode('utf-8'))
+        xbmc.log("KCLEANER >> ERROR PARSING REPO >> " + str(e))
         return ""
 
     infoTag = xmldoc.getElementsByTagName("addon")


### PR DESCRIPTION
after upgrading to python3, im getting this error while performing these checks:
```
ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'TypeError'>
                                                   Error Contents: can only concatenate str (not "bytes") to str
                                                   Traceback (most recent call last):
                                                     File "C:\Users\home\AppData\Roaming\Kodi\addons\script.kcleaner\default.py", line 1262, in getPathAddons
                                                       xmldoc = minidom.parseString(httpdata)
                                                     File "C:\Program Files (x86)\Kodi\system\python\Lib\xml\dom\minidom.py", line 1969, in parseString
                                                       return expatbuilder.parseString(string)
                                                     File "C:\Program Files (x86)\Kodi\system\python\Lib\xml\dom\expatbuilder.py", line 925, in parseString
                                                       return builder.parseString(string)
                                                     File "C:\Program Files (x86)\Kodi\system\python\Lib\xml\dom\expatbuilder.py", line 223, in parseString
                                                       parser.Parse(string, True)
                                                   xml.parsers.expat.ExpatError: not well-formed (invalid token): line 186, column 79
                                                   
                                                   During handling of the above exception, another exception occurred:
                                                   
                                                   Traceback (most recent call last):
                                                     File "C:\Users\home\AppData\Roaming\Kodi\addons\script.kcleaner\default.py", line 1963, in <module>
                                                       intCancel = ProcessAddons(0)
                                                     File "C:\Users\home\AppData\Roaming\Kodi\addons\script.kcleaner\default.py", line 1053, in ProcessAddons
                                                       AddonsInRepo += GetAddonsInRepo(repoxml, r)
                                                     File "C:\Users\home\AppData\Roaming\Kodi\addons\script.kcleaner\default.py", line 1190, in GetAddonsInRepo
                                                       id = getPathAddons(ri, repo)
                                                     File "C:\Users\home\AppData\Roaming\Kodi\addons\script.kcleaner\default.py", line 1264, in getPathAddons
                                                       xbmc.log("KCLEANER >> ERROR PARSING REPO >> " + str(e).encode('utf-8'))
                                                   TypeError: can only concatenate str (not "bytes") to str
                                                   -->End of Python script error report<--
```